### PR TITLE
Refactor OAuth factory slightly and rename Http impl to Twitch specific

### DIFF
--- a/server/src/main/scala/com/github/saxypandabear/songrequests/oauth/TwitchOauthTokenManager.scala
+++ b/server/src/main/scala/com/github/saxypandabear/songrequests/oauth/TwitchOauthTokenManager.scala
@@ -1,7 +1,6 @@
 package com.github.saxypandabear.songrequests.oauth
 
 import com.github.saxypandabear.songrequests.ddb.ConnectionDataStore
-import com.github.saxypandabear.songrequests.oauth.factory.OauthTokenManagerFactory
 import com.github.saxypandabear.songrequests.util.{HttpUtil, JsonUtil}
 
 /**
@@ -27,7 +26,7 @@ class TwitchOauthTokenManager(
    * Retrieve an access token
    * @return an OAuth access token
    */
-  def getAccessToken: String = connection.twitchAccessToken()
+  override def getAccessToken: String = connection.twitchAccessToken()
 
   /**
    * Performs the token refresh, and also persists the change to DynamoDB
@@ -64,42 +63,4 @@ class TwitchOauthTokenManager(
         )
       }
     }
-}
-
-object HttpOauthTokenManagerFactory extends OauthTokenManagerFactory {
-
-  /**
-   * Create some implementation of an OAuth token manager.
-   * @param clientId            application client id
-   * @param clientSecret        application client secret
-   * @param channelId           Twitch channel ID
-   * @param refreshUri          URI for re-authentication
-   * @param connectionDataStore database wrapper that stores the bulk of
-   *                            connection information
-   * @return an implementation of an OAuth token manager
-   */
-  override def create(
-      clientId: String,
-      clientSecret: String,
-      channelId: String,
-      refreshUri: String,
-      connectionDataStore: ConnectionDataStore
-  ): OauthTokenManager = {
-    // just need to extract the refresh token from the database
-    // TODO: because of how this is written, there are 2 database reads.
-    //       look into refactoring this so we only need to read once on
-    //       initialization instead of twice to optimize.
-    val refreshToken = connectionDataStore
-      .getConnectionDetailsById(channelId)
-      .twitchRefreshToken()
-
-    new TwitchOauthTokenManager(
-        clientId,
-        clientSecret,
-        channelId,
-        refreshUri,
-        refreshToken,
-        connectionDataStore
-    )
-  }
 }

--- a/server/src/main/scala/com/github/saxypandabear/songrequests/oauth/TwitchOauthTokenManager.scala
+++ b/server/src/main/scala/com/github/saxypandabear/songrequests/oauth/TwitchOauthTokenManager.scala
@@ -1,6 +1,7 @@
 package com.github.saxypandabear.songrequests.oauth
 
 import com.github.saxypandabear.songrequests.ddb.ConnectionDataStore
+import com.github.saxypandabear.songrequests.oauth.factory.OauthTokenManagerFactory
 import com.github.saxypandabear.songrequests.util.{HttpUtil, JsonUtil}
 
 /**

--- a/server/src/main/scala/com/github/saxypandabear/songrequests/oauth/factory/OauthTokenManagerFactory.scala
+++ b/server/src/main/scala/com/github/saxypandabear/songrequests/oauth/factory/OauthTokenManagerFactory.scala
@@ -1,6 +1,7 @@
-package com.github.saxypandabear.songrequests.oauth
+package com.github.saxypandabear.songrequests.oauth.factory
 
 import com.github.saxypandabear.songrequests.ddb.ConnectionDataStore
+import com.github.saxypandabear.songrequests.oauth.OauthTokenManager
 
 trait OauthTokenManagerFactory {
 

--- a/server/src/main/scala/com/github/saxypandabear/songrequests/oauth/factory/TwitchOauthTokenManagerFactory.scala
+++ b/server/src/main/scala/com/github/saxypandabear/songrequests/oauth/factory/TwitchOauthTokenManagerFactory.scala
@@ -1,6 +1,9 @@
 package com.github.saxypandabear.songrequests.oauth.factory
 import com.github.saxypandabear.songrequests.ddb.ConnectionDataStore
-import com.github.saxypandabear.songrequests.oauth.OauthTokenManager
+import com.github.saxypandabear.songrequests.oauth.{
+  OauthTokenManager,
+  TwitchOauthTokenManager
+}
 
 object TwitchOauthTokenManagerFactory extends OauthTokenManagerFactory {
 
@@ -20,6 +23,20 @@ object TwitchOauthTokenManagerFactory extends OauthTokenManagerFactory {
       channelId: String,
       refreshUri: String,
       connectionDataStore: ConnectionDataStore
-  ): OauthTokenManager =
-    null // TODO: implement me
+  ): OauthTokenManager = {
+    // TODO: this does two database reads. if this becomes a bottleneck,
+    //       need to refactor this
+    val refreshToken = connectionDataStore
+      .getConnectionDetailsById(channelId)
+      .twitchRefreshToken()
+
+    new TwitchOauthTokenManager(
+        clientId,
+        clientSecret,
+        channelId,
+        refreshUri,
+        refreshToken,
+        connectionDataStore
+    )
+  }
 }

--- a/server/src/main/scala/com/github/saxypandabear/songrequests/oauth/factory/TwitchOauthTokenManagerFactory.scala
+++ b/server/src/main/scala/com/github/saxypandabear/songrequests/oauth/factory/TwitchOauthTokenManagerFactory.scala
@@ -1,0 +1,25 @@
+package com.github.saxypandabear.songrequests.oauth.factory
+import com.github.saxypandabear.songrequests.ddb.ConnectionDataStore
+import com.github.saxypandabear.songrequests.oauth.OauthTokenManager
+
+object TwitchOauthTokenManagerFactory extends OauthTokenManagerFactory {
+
+  /**
+   * Create some implementation of an OAuth token manager.
+   * @param clientId            application client id
+   * @param clientSecret        application client secret
+   * @param channelId           Twitch channel ID
+   * @param refreshUri          URI for re-authentication
+   * @param connectionDataStore database wrapper that stores the bulk of
+   *                            connection information
+   * @return an implementation of an OAuth token manager
+   */
+  override def create(
+      clientId: String,
+      clientSecret: String,
+      channelId: String,
+      refreshUri: String,
+      connectionDataStore: ConnectionDataStore
+  ): OauthTokenManager =
+    null // TODO: implement me
+}

--- a/server/src/main/scala/com/github/saxypandabear/songrequests/websocket/TwitchSocketFactory.scala
+++ b/server/src/main/scala/com/github/saxypandabear/songrequests/websocket/TwitchSocketFactory.scala
@@ -2,7 +2,7 @@ package com.github.saxypandabear.songrequests.websocket
 
 import com.github.saxypandabear.songrequests.ddb.ConnectionDataStore
 import com.github.saxypandabear.songrequests.metric.CloudWatchMetricCollector
-import com.github.saxypandabear.songrequests.oauth.OauthTokenManagerFactory
+import com.github.saxypandabear.songrequests.oauth.factory.OauthTokenManagerFactory
 import com.github.saxypandabear.songrequests.queue.SongQueue
 import com.github.saxypandabear.songrequests.websocket.listener.WebSocketListener
 

--- a/server/src/test/java/com/github/saxypandabear/songrequests/ddb/DynamoDbConnectionDataStoreIntegrationTest.java
+++ b/server/src/test/java/com/github/saxypandabear/songrequests/ddb/DynamoDbConnectionDataStoreIntegrationTest.java
@@ -34,8 +34,11 @@ public class DynamoDbConnectionDataStoreIntegrationTest {
 
     private static final String connectionTemplateJsonPath = "test-json/connection-active.json";
 
+    // TODO: may need to investigate why the first test times out in 5 seconds.
+    //       5 seconds should be a generous amount of time to finish standing
+    //       up the infrastructure for the DynamoDB testing.
     @Rule
-    public Timeout globalTimeout = new Timeout(5, TimeUnit.SECONDS);
+    public Timeout globalTimeout = new Timeout(8, TimeUnit.SECONDS);
 
     private DynamoDbConnectionDataStore dataStore;
     private AmazonDynamoDB ddb;

--- a/server/src/test/scala/com/github/saxypandabear/songrequests/oauth/TestTokenManager.scala
+++ b/server/src/test/scala/com/github/saxypandabear/songrequests/oauth/TestTokenManager.scala
@@ -2,14 +2,6 @@ package com.github.saxypandabear.songrequests.oauth
 
 import java.util.UUID
 
-import com.github.saxypandabear.songrequests.ddb.model.Connection
-import com.github.saxypandabear.songrequests.ddb.{
-  ConnectionDataStore,
-  InMemoryConnectionDataStore
-}
-import com.github.saxypandabear.songrequests.util.JsonUtil.objectMapper
-import com.typesafe.scalalogging.LazyLogging
-
 import scala.collection.mutable
 
 class TestTokenManager(
@@ -64,65 +56,5 @@ object TestTokenManager {
   def flush(): Unit = {
     refreshEvents.clear()
     clientIdsToTokens.clear()
-  }
-}
-
-object TestTokenManagerFactory
-    extends OauthTokenManagerFactory
-    with LazyLogging {
-
-  // use this to leverage Scala's case class functionality in order to simply
-  // copy the base object and change just the channel ID
-  private val baseConnectionObj = objectMapper.readValue(
-      getClass.getClassLoader.getResourceAsStream(
-          "test-json/connection-active.json"
-      ),
-      classOf[Connection]
-  )
-
-  /**
-   * Create some implementation of an OAuth token manager.
-   * Note that for this test factory, if the channel ID does not exist in the
-   * data store, we expect to generate one. Doing it here abstracts away the
-   * work in the tests, and in practice, we expect the channel ID to exist
-   * when it reaches this service.
-   * @param clientId            application client id
-   * @param clientSecret        application client secret
-   * @param channelId           Twitch channel ID
-   * @param refreshUri          URI for re-authentication
-   * @param connectionDataStore database wrapper that stores the bulk of
-   *                            connection information
-   * @return an implementation of an OAuth token manager
-   */
-  override def create(
-      clientId: String,
-      clientSecret: String,
-      channelId: String,
-      refreshUri: String,
-      connectionDataStore: ConnectionDataStore
-  ): OauthTokenManager = {
-    if (!connectionDataStore.isInstanceOf[InMemoryConnectionDataStore]) {
-      throw new IllegalArgumentException(
-          "Test token manager expects a local connection data store implementation"
-      )
-    }
-
-    // if we don't have this channel ID yet, then create it and store it
-    // before continuing
-    if (!connectionDataStore.hasConnectionDetails(channelId)) {
-      connectionDataStore
-        .asInstanceOf[InMemoryConnectionDataStore]
-        .putConnectionDetails(
-            channelId,
-            baseConnectionObj.copy(channelId = channelId)
-        )
-    }
-    val connection = connectionDataStore.getConnectionDetailsById(channelId)
-    new TestTokenManager(
-        clientId,
-        clientSecret,
-        connection.twitchRefreshToken(),
-        refreshUri
-    )
   }
 }

--- a/server/src/test/scala/com/github/saxypandabear/songrequests/oauth/factory/TestTokenManagerFactory.scala
+++ b/server/src/test/scala/com/github/saxypandabear/songrequests/oauth/factory/TestTokenManagerFactory.scala
@@ -1,0 +1,73 @@
+package com.github.saxypandabear.songrequests.oauth.factory
+
+import com.github.saxypandabear.songrequests.ddb.model.Connection
+import com.github.saxypandabear.songrequests.ddb.{
+  ConnectionDataStore,
+  InMemoryConnectionDataStore
+}
+import com.github.saxypandabear.songrequests.oauth.{
+  OauthTokenManager,
+  TestTokenManager
+}
+import com.github.saxypandabear.songrequests.util.JsonUtil.objectMapper
+import com.typesafe.scalalogging.LazyLogging
+
+object TestTokenManagerFactory
+    extends OauthTokenManagerFactory
+    with LazyLogging {
+
+  // use this to leverage Scala's case class functionality in order to simply
+  // copy the base object and change just the channel ID
+  private val baseConnectionObj = objectMapper.readValue(
+      getClass.getClassLoader.getResourceAsStream(
+          "test-json/connection-active.json"
+      ),
+      classOf[Connection]
+  )
+
+  /**
+   * Create some implementation of an OAuth token manager.
+   * Note that for this test factory, if the channel ID does not exist in the
+   * data store, we expect to generate one. Doing it here abstracts away the
+   * work in the tests, and in practice, we expect the channel ID to exist
+   * when it reaches this service.
+   * @param clientId            application client id
+   * @param clientSecret        application client secret
+   * @param channelId           Twitch channel ID
+   * @param refreshUri          URI for re-authentication
+   * @param connectionDataStore database wrapper that stores the bulk of
+   *                            connection information
+   * @return an implementation of an OAuth token manager
+   */
+  override def create(
+      clientId: String,
+      clientSecret: String,
+      channelId: String,
+      refreshUri: String,
+      connectionDataStore: ConnectionDataStore
+  ): OauthTokenManager = {
+    if (!connectionDataStore.isInstanceOf[InMemoryConnectionDataStore]) {
+      throw new IllegalArgumentException(
+          "Test token manager expects a local connection data store implementation"
+      )
+    }
+
+    // if we don't have this channel ID yet, then create it and store it
+    // before continuing
+    if (!connectionDataStore.hasConnectionDetails(channelId)) {
+      connectionDataStore
+        .asInstanceOf[InMemoryConnectionDataStore]
+        .putConnectionDetails(
+            channelId,
+            baseConnectionObj.copy(channelId = channelId)
+        )
+    }
+    val connection = connectionDataStore.getConnectionDetailsById(channelId)
+    new TestTokenManager(
+        clientId,
+        clientSecret,
+        connection.twitchRefreshToken(),
+        refreshUri
+    )
+  }
+}

--- a/server/src/test/scala/com/github/saxypandabear/songrequests/websocket/integration/RoundRobinConnectionOrchestratorIntegrationSpec.scala
+++ b/server/src/test/scala/com/github/saxypandabear/songrequests/websocket/integration/RoundRobinConnectionOrchestratorIntegrationSpec.scala
@@ -10,7 +10,7 @@ import com.github.saxypandabear.songrequests.lib.{
   UnitSpec
 }
 import com.github.saxypandabear.songrequests.metric.CloudWatchMetricCollector
-import com.github.saxypandabear.songrequests.oauth.TestTokenManagerFactory
+import com.github.saxypandabear.songrequests.oauth.factory.TestTokenManagerFactory
 import com.github.saxypandabear.songrequests.queue.InMemorySongQueue
 import com.github.saxypandabear.songrequests.websocket.TwitchSocketFactory
 import com.github.saxypandabear.songrequests.websocket.lib.WebSocketTestingUtil


### PR DESCRIPTION
In preparation for developing a shared scala lib used across the server and lambda code, clearly separate the Twitch oauth implementation from "HTTP", since both Spotify and Twitch use OAuth 2.0 over HTTP, but have slightly different implementations